### PR TITLE
consistent int -> number translation in whatisgenerated.rst

### DIFF
--- a/source/whatisgenerated.rst
+++ b/source/whatisgenerated.rst
@@ -176,8 +176,8 @@ All collection or nested collection types will be exported by TypeGen. E.g., for
 	export class MyClass {
 	    intArray: number[];
 	    intEnumerable: number[];
-	    intEnumArrayCombo: int[][];
-	    intEnumListArrayCombo: int[][][];
+	    intEnumArrayCombo: number[][];
+	    intEnumListArrayCombo: number[][][];
 	}
 
 Base classes


### PR DESCRIPTION
I saw an inconsistency in the docs that drew my attention.  I thought maybe there was a new `int` type in JavaScript I hadn't heard about. :p